### PR TITLE
Bug Fix: Docker Container Service Health check bug in `make docker-demo`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,12 +354,6 @@ docker-demo: check-env kill-ports install
 	docker compose up -d
 	@echo "All services are now running with the following ports:"
 	@$(MAKE) show-ports
-	@echo "\n========== WAITING FOR SERVICES TO BE HEALTHY =========="
-	@$(MAKE) wait-for-service SERVICE=coordinator
-	@$(MAKE) wait-for-service SERVICE=github-sensor
-	@$(MAKE) wait-for-service SERVICE=hackmd-sensor
-	@$(MAKE) wait-for-service SERVICE=github-processor
-	@$(MAKE) wait-for-service SERVICE=hackmd-processor
 	@echo "\n========== ALL SERVICES ARE HEALTHY =========="
 	@echo "\n========== SYSTEM STATUS REPORTS =========="
 	@echo "\n=== GitHub Repository Status ==="

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Each node operates independently with its own configuration, database, and API.
 ## Prerequisites
 
 - Python 3.12+
-- Docker and Docker Compose v2+ (for Docker deployment)
+- Docker and Docker Compose v2.1+ (for Docker deployment)
 - Git
 - Make (optional, see Implementation Details for alternatives)
 


### PR DESCRIPTION
Bug Fix: Docker Container Service Health check bug in `make docker-demo`

Environment:
- OS: MacOS Sonoma - Version 14.6.1
- Processor: Apple M1 Max (ARM64)

Command: `make docker-demo`'s usage of `wait-for-service` after `docker compose up -d`

Issue:
- Description:
  - Despite Nodes being reported as healthy by `docker compose up -d` (`:heavy_check_mark: Container koi-net-demo-v1-coordinator-1     Healthy    `) from the HEALTHCHECK in the Dockerfile, Makefile's `@$(MAKE) wait-for-service SERVICE=coordinator` is stuck in feedback loop "WAITING FOR SERVICES TO BE HEALTHY" reporting `Still waiting for coordinator (0s elapsed)... Current status:`
- Suggested Solution:
  - Ensure Docker Compose version >= 2.1
  - remove Makefile's docker-demo's "WAITING FOR SERVICES TO BE HEALTHY"
- Justification:
  - Docker Compose version >= 2.1 will render Makefile's docker-demo's "WAITING FOR SERVICES TO BE HEALTHY" is unnecessary because the `docker compose up -d` command will wait until Dockerfiles' `HEALTHCHECK`s pass due to the `services` in `docker-compose.yml` `depends_on` conditions being `service_healthy`.