### PR TITLE
Bug Fix: Docker Container Service Health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Each node operates independently with its own configuration, database, and API.
 ## Prerequisites
 
 - Python 3.12+
-- Docker and Docker Compose v2+ (for Docker deployment)
+- Docker and Docker Compose v2.1+ (for Docker deployment)
 - Git
 - Make (optional, see Implementation Details for alternatives)
 


### PR DESCRIPTION
Bug Fix: Issue: #5 
- Problem Command(s): `make docker-demo`'s usage of `wait-for-service` after `docker compose up -d` stuck waiting for service health
- Solution:
  - Specified Docker Compose version >= 2.1 in Readme
  - remove Makefile's docker-demo's "WAITING FOR SERVICES TO BE HEALTHY"
- Supporting Documentation:
  - https://docs.docker.com/guides/docker-compose/common-questions/#how-can-i-enforce-the-database-service-to-start-up-before-the-frontend-service

Environment:
- OS: MacOS Sonoma - Version 14.6.1
- Processor: Apple M1 Max (ARM64)